### PR TITLE
Limit concurrency of jobs touching the package repository.

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch: {}
 
+concurrency:
+  group: package-repository
+  cancel-in-progress: false
+
 jobs:
   # A job to delete obsolete package versions (container images) from the GitHub registry.
   delete_container_images:

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [ closed ]
 
+concurrency:
+  group: package-repository
+  cancel-in-progress: false
+
 jobs:
   # A job to delete package versions (container images) from the GitHub registry related to the PR.
   delete_container_images:


### PR DESCRIPTION
This PR ensures that jobs touching the package repository do not run in parallel to avoid conflicting modifications. For example, one job may delete a version while another is scanning the repository. This may lead to errors in the second job because it may discover a version and then fail to download the corresponding manifest because it was just deleted by the first job.